### PR TITLE
Added Edge Cloud token provider, refactored token provider to DI

### DIFF
--- a/cmd/gke-gcloud-auth-plugin/main.go
+++ b/cmd/gke-gcloud-auth-plugin/main.go
@@ -12,6 +12,9 @@ import (
 
 var (
 	useApplicationDefaultCredentials = pflag.Bool("use_application_default_credentials", false, "Output is an ExecCredential filled with application default credentials.")
+	useEdgeCloud					 = pflag.Bool("use_edge_cloud", false, "Output is an ExecCredential for an edge cloud cluster.")
+	location						 = pflag.String("location", "", "Location of the Cluster.")
+	cluster							 = pflag.String("cluster", "", "Name of the Cluster.")
 )
 
 func main() {
@@ -21,9 +24,30 @@ func main() {
 	pflag.Parse()
 
 	verflag.PrintAndExitIfRequested()
+	validateFlags()
 
-	opts := &cred.Options{UseApplicationDefaultCredentials: *useApplicationDefaultCredentials}
+	var edgeCloudOpts *cred.EdgeCloudOptions = nil
+	if *useEdgeCloud {
+		edgeCloudOpts = &cred.EdgeCloudOptions{Location: *location, ClusterName: *cluster}
+	}
+
+	opts := &cred.Options{
+		UseApplicationDefaultCredentials: *useApplicationDefaultCredentials,
+		EdgeCloud: edgeCloudOpts,
+	}
+
 	if err := cred.PrintCred(opts); err != nil {
 		klog.Exit(fmt.Errorf("print credential failed with error: %w", err))
+	}
+}
+
+func validateFlags() {
+	if *useEdgeCloud {
+		if *useApplicationDefaultCredentials {
+			klog.Exit(fmt.Errorf("For --use_edge_cloud: application default credentials are not compatible."))
+		}
+		if *location == "" || *cluster == "" {
+			klog.Exit(fmt.Errorf("For --use_edge_cloud: --location and --cluster are required."))
+		}
 	}
 }


### PR DESCRIPTION
Add support for EdgeCloud to gke-gcloud-auth-plugin.

Refactor existing branched logic for topic retrieval to a Dependency Injection pattern. This allows for maximum code sharing in caching and cache-validation. It also removes provider-specific configurations from the plugin. It also helped prevent a pile-up of conditional statements throughout the caching logic to check which type of token provider is being handled.
Introduction of "Token Provider Context" was necessary to detect if a cached token is valid, as it should only be valid if the command which retrieved the cached token is the same as the current command. The migration story is that existing caches will be invalidated, and replaced upon upgrade.
Add unit tests for EdgeCloud scenarios.